### PR TITLE
Removal of master-slave language

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func init() {
 	rootCmd.AddCommand(globalStatusCmd)
 	rootCmd.AddCommand(globalVariablesCmd)
 	rootCmd.AddCommand(innodbStatusCmd)
-	rootCmd.AddCommand(slaveStatusCmd)
+	rootCmd.AddCommand(subordinateStatusCmd)
 }
 
 var rootCmd = &cobra.Command{
@@ -76,8 +76,8 @@ var innodbStatusCmd = &cobra.Command{
 	},
 }
 
-var slaveStatusCmd = &cobra.Command{
-	Use:   "slave_status",
+var subordinateStatusCmd = &cobra.Command{
+	Use:   "subordinate_status",
 	Short: "JSONize SHOW SLAVE STATUS OUTPUT from stdin",
 	Long:  "",
 	Run: func(cmd *cobra.Command, args []string) {
@@ -85,7 +85,7 @@ var slaveStatusCmd = &cobra.Command{
 		if err != nil {
 			fmt.Fprint(os.Stderr, err.Error())
 		} else {
-			parser.JSONizeSlaveStatus(string(stdin))
+			parser.JSONizeSubordinateStatus(string(stdin))
 		}
 	},
 }

--- a/parser/global_status_test.go
+++ b/parser/global_status_test.go
@@ -36,7 +36,7 @@ Com_begin	0
 Com_binlog	0
 Com_call_procedure	0
 Com_change_db	0
-Com_change_master	0
+Com_change_main	0
 Com_change_repl_filter	0
 Com_check	0
 Com_checksum	0
@@ -124,7 +124,7 @@ Com_show_function_code	0
 Com_show_function_status	0
 Com_show_grants	0
 Com_show_keys	0
-Com_show_master_status	0
+Com_show_main_status	0
 Com_show_open_tables	0
 Com_show_plugins	0
 Com_show_privileges	0
@@ -134,8 +134,8 @@ Com_show_processlist	0
 Com_show_profile	0
 Com_show_profiles	0
 Com_show_relaylog_events	0
-Com_show_slave_hosts	0
-Com_show_slave_status	0
+Com_show_subordinate_hosts	0
+Com_show_subordinate_status	0
 Com_show_status	8
 Com_show_storage_engines	0
 Com_show_table_status	0
@@ -145,8 +145,8 @@ Com_show_variables	1
 Com_show_warnings	0
 Com_show_create_user	0
 Com_shutdown	0
-Com_slave_start	0
-Com_slave_stop	0
+Com_subordinate_start	0
+Com_subordinate_stop	0
 Com_group_replication_start	0
 Com_group_replication_stop	0
 Com_stmt_execute	0
@@ -319,7 +319,7 @@ Select_full_range_join	0
 Select_range	0
 Select_range_check	0
 Select_scan	18
-Slave_open_temp_tables	0
+Subordinate_open_temp_tables	0
 Slow_launch_threads	0
 Slow_queries	0
 Sort_merge_passes	0
@@ -395,7 +395,7 @@ var (
 		"com_binlog":                                    0.0,
 		"com_call_procedure":                            0.0,
 		"com_change_db":                                 0.0,
-		"com_change_master":                             0.0,
+		"com_change_main":                             0.0,
 		"com_change_repl_filter":                        0.0,
 		"com_check":                                     0.0,
 		"com_checksum":                                  0.0,
@@ -485,7 +485,7 @@ var (
 		"com_show_function_status":                      0.0,
 		"com_show_grants":                               0.0,
 		"com_show_keys":                                 0.0,
-		"com_show_master_status":                        0.0,
+		"com_show_main_status":                        0.0,
 		"com_show_open_tables":                          0.0,
 		"com_show_plugins":                              0.0,
 		"com_show_privileges":                           0.0,
@@ -495,8 +495,8 @@ var (
 		"com_show_profile":                              0.0,
 		"com_show_profiles":                             0.0,
 		"com_show_relaylog_events":                      0.0,
-		"com_show_slave_hosts":                          0.0,
-		"com_show_slave_status":                         0.0,
+		"com_show_subordinate_hosts":                          0.0,
+		"com_show_subordinate_status":                         0.0,
 		"com_show_status":                               8.0,
 		"com_show_storage_engines":                      0.0,
 		"com_show_table_status":                         0.0,
@@ -506,8 +506,8 @@ var (
 		"com_show_warnings":                             0.0,
 		"com_shutdown":                                  0.0,
 		"com_signal":                                    0.0,
-		"com_slave_start":                               0.0,
-		"com_slave_stop":                                0.0,
+		"com_subordinate_start":                               0.0,
+		"com_subordinate_stop":                                0.0,
 		"com_stmt_close":                                0.0,
 		"com_stmt_execute":                              0.0,
 		"com_stmt_fetch":                                0.0,
@@ -673,7 +673,7 @@ var (
 		"select_range":                                  0.0,
 		"select_range_check":                            0.0,
 		"select_scan":                                   18.0,
-		"slave_open_temp_tables":                        0.0,
+		"subordinate_open_temp_tables":                        0.0,
 		"slow_launch_threads":                           0.0,
 		"slow_queries":                                  0.0,
 		"sort_merge_passes":                             0.0,

--- a/parser/global_variables_test.go
+++ b/parser/global_variables_test.go
@@ -108,7 +108,7 @@ ignore_builtin_innodb	OFF
 ignore_db_dirs
 init_connect
 init_file
-init_slave
+init_subordinate
 innodb_adaptive_flushing	ON
 innodb_adaptive_flushing_lwm	10
 innodb_adaptive_hash_index	ON
@@ -271,9 +271,9 @@ log_error	stderr
 log_error_verbosity	3
 log_output	FILE
 log_queries_not_using_indexes	OFF
-log_slave_updates	OFF
+log_subordinate_updates	OFF
 log_slow_admin_statements	OFF
-log_slow_slave_statements	OFF
+log_slow_subordinate_statements	OFF
 log_statements_unsafe_for_binlog	ON
 log_syslog	OFF
 log_syslog_facility	daemon
@@ -286,8 +286,8 @@ long_query_time	10.000000
 low_priority_updates	OFF
 lower_case_file_system	OFF
 lower_case_table_names	0
-master_info_repository	FILE
-master_verify_checksum	OFF
+main_info_repository	FILE
+main_verify_checksum	OFF
 max_allowed_packet	4194304
 max_binlog_cache_size	18446744073709547520
 max_binlog_size	1073741824
@@ -419,7 +419,7 @@ report_password
 report_port	3306
 report_user
 require_secure_transport	OFF
-rpl_stop_slave_timeout	31536000
+rpl_stop_subordinate_timeout	31536000
 secure_auth	ON
 secure_file_priv	/var/lib/mysql-files/
 server_id	1
@@ -441,23 +441,23 @@ skip_external_locking	ON
 skip_name_resolve	ON
 skip_networking	OFF
 skip_show_database	OFF
-slave_allow_batching	OFF
-slave_checkpoint_group	512
-slave_checkpoint_period	300
-slave_compressed_protocol	OFF
-slave_exec_mode	STRICT
-slave_load_tmpdir	/tmp
-slave_max_allowed_packet	1073741824
-slave_net_timeout	60
-slave_parallel_type	DATABASE
-slave_parallel_workers	0
-slave_pending_jobs_size_max	16777216
-slave_preserve_commit_order	OFF
-slave_rows_search_algorithms	TABLE_SCAN,INDEX_SCAN
-slave_skip_errors	OFF
-slave_sql_verify_checksum	ON
-slave_transaction_retries	10
-slave_type_conversions
+subordinate_allow_batching	OFF
+subordinate_checkpoint_group	512
+subordinate_checkpoint_period	300
+subordinate_compressed_protocol	OFF
+subordinate_exec_mode	STRICT
+subordinate_load_tmpdir	/tmp
+subordinate_max_allowed_packet	1073741824
+subordinate_net_timeout	60
+subordinate_parallel_type	DATABASE
+subordinate_parallel_workers	0
+subordinate_pending_jobs_size_max	16777216
+subordinate_preserve_commit_order	OFF
+subordinate_rows_search_algorithms	TABLE_SCAN,INDEX_SCAN
+subordinate_skip_errors	OFF
+subordinate_sql_verify_checksum	ON
+subordinate_transaction_retries	10
+subordinate_type_conversions
 slow_launch_time	2
 slow_query_log	OFF
 slow_query_log_file	/var/lib/mysql/70d6bc44c952-slow.log
@@ -472,7 +472,7 @@ sql_notes	ON
 sql_quote_show_create	ON
 sql_safe_updates	OFF
 sql_select_limit	18446744073709551615
-sql_slave_skip_counter	0
+sql_subordinate_skip_counter	0
 sql_warnings	OFF
 ssl_ca	ca.pem
 ssl_capath
@@ -485,7 +485,7 @@ stored_program_cache	256
 super_read_only	OFF
 sync_binlog	1
 sync_frm	ON
-sync_master_info	10000
+sync_main_info	10000
 sync_relay_log	10000
 sync_relay_log_info	10000
 system_time_zone	JST
@@ -759,9 +759,9 @@ var (
 		"log_error_verbosity":                                3.0,
 		"log_output":                                         "FILE",
 		"log_queries_not_using_indexes":                      "OFF",
-		"log_slave_updates":                                  "OFF",
+		"log_subordinate_updates":                                  "OFF",
 		"log_slow_admin_statements":                          "OFF",
-		"log_slow_slave_statements":                          "OFF",
+		"log_slow_subordinate_statements":                          "OFF",
 		"log_statements_unsafe_for_binlog":                   "ON",
 		"log_syslog":                                         "OFF",
 		"log_syslog_facility":                                "daemon",
@@ -773,8 +773,8 @@ var (
 		"low_priority_updates":                               "OFF",
 		"lower_case_file_system":                             "OFF",
 		"lower_case_table_names":                             0.0,
-		"master_info_repository":                             "FILE",
-		"master_verify_checksum":                             "OFF",
+		"main_info_repository":                             "FILE",
+		"main_verify_checksum":                             "OFF",
 		"max_allowed_packet":                                 4.194304e+06,
 		"max_binlog_cache_size":                              1.8446744073709548e+19,
 		"max_binlog_size":                                    1.073741824e+09,
@@ -902,7 +902,7 @@ var (
 		"relay_log_space_limit":                                    0.0,
 		"report_port":                                              3306.0,
 		"require_secure_transport":                                 "OFF",
-		"rpl_stop_slave_timeout":                                   3.1536e+07,
+		"rpl_stop_subordinate_timeout":                                   3.1536e+07,
 		"secure_auth":                                              "ON",
 		"secure_file_priv":                                         "/var/lib/mysql-files/",
 		"server_id":                                                1.0,
@@ -924,22 +924,22 @@ var (
 		"skip_name_resolve":                                        "ON",
 		"skip_networking":                                          "OFF",
 		"skip_show_database":                                       "OFF",
-		"slave_allow_batching":                                     "OFF",
-		"slave_checkpoint_group":                                   512.0,
-		"slave_checkpoint_period":                                  300.0,
-		"slave_compressed_protocol":                                "OFF",
-		"slave_exec_mode":                                          "STRICT",
-		"slave_load_tmpdir":                                        "/tmp",
-		"slave_max_allowed_packet":                                 1.073741824e+09,
-		"slave_net_timeout":                                        60.0,
-		"slave_parallel_type":                                      "DATABASE",
-		"slave_parallel_workers":                                   0.0,
-		"slave_pending_jobs_size_max":                              1.6777216e+07,
-		"slave_preserve_commit_order":                              "OFF",
-		"slave_rows_search_algorithms":                             "TABLE_SCAN,INDEX_SCAN",
-		"slave_skip_errors":                                        "OFF",
-		"slave_sql_verify_checksum":                                "ON",
-		"slave_transaction_retries":                                10.0,
+		"subordinate_allow_batching":                                     "OFF",
+		"subordinate_checkpoint_group":                                   512.0,
+		"subordinate_checkpoint_period":                                  300.0,
+		"subordinate_compressed_protocol":                                "OFF",
+		"subordinate_exec_mode":                                          "STRICT",
+		"subordinate_load_tmpdir":                                        "/tmp",
+		"subordinate_max_allowed_packet":                                 1.073741824e+09,
+		"subordinate_net_timeout":                                        60.0,
+		"subordinate_parallel_type":                                      "DATABASE",
+		"subordinate_parallel_workers":                                   0.0,
+		"subordinate_pending_jobs_size_max":                              1.6777216e+07,
+		"subordinate_preserve_commit_order":                              "OFF",
+		"subordinate_rows_search_algorithms":                             "TABLE_SCAN,INDEX_SCAN",
+		"subordinate_skip_errors":                                        "OFF",
+		"subordinate_sql_verify_checksum":                                "ON",
+		"subordinate_transaction_retries":                                10.0,
 		"slow_launch_time":                                         2.0,
 		"slow_query_log":                                           "OFF",
 		"slow_query_log_file":                                      "/var/lib/mysql/70d6bc44c952-slow.log",
@@ -954,7 +954,7 @@ var (
 		"sql_quote_show_create":                                    "ON",
 		"sql_safe_updates":                                         "OFF",
 		"sql_select_limit":                                         1.8446744073709552e+19,
-		"sql_slave_skip_counter":                                   0.0,
+		"sql_subordinate_skip_counter":                                   0.0,
 		"sql_warnings":                                             "OFF",
 		"ssl_ca":                                                   "ca.pem",
 		"ssl_cert":                                                 "server-cert.pem",
@@ -963,7 +963,7 @@ var (
 		"super_read_only":                                          "OFF",
 		"sync_binlog":                                              1.0,
 		"sync_frm":                                                 "ON",
-		"sync_master_info":                                         10000.0,
+		"sync_main_info":                                         10000.0,
 		"sync_relay_log":                                           10000.0,
 		"sync_relay_log_info":                                      10000.0,
 		"system_time_zone":                                         "JST",

--- a/parser/innodb_status.go
+++ b/parser/innodb_status.go
@@ -231,7 +231,7 @@ func parseStartOfInnodbMonitorOutput(content []string) map[string]interface{} {
 func parseBackgroundThreadContent(content []string) map[string]interface{} {
 	result := make(map[string]interface{})
 	for _, line := range content {
-		item := "srv_master_thread loops: "
+		item := "srv_main_thread loops: "
 		if strings.HasPrefix(line, item) {
 			parts := strings.Split(line, ", ")
 			active, shutdown, idle := parts[0], parts[1], parts[2]
@@ -255,7 +255,7 @@ func parseBackgroundThreadContent(content []string) map[string]interface{} {
 			result = fillMetric("background_idle_thread_loops", metricIdle[0], result)
 		}
 
-		item = "srv_master_thread log flush and writes: "
+		item = "srv_main_thread log flush and writes: "
 		if strings.HasPrefix(line, item) {
 			/*
 			 * The total number of background thread's log flush/write operations

--- a/parser/innodb_status_test.go
+++ b/parser/innodb_status_test.go
@@ -21,8 +21,8 @@ Per second averages calculated from the last 6 seconds
 -----------------
 BACKGROUND THREAD
 -----------------
-srv_master_thread loops: 178 srv_active, 0 srv_shutdown, 1244368 srv_idle
-srv_master_thread log flush and writes: 1244546
+srv_main_thread loops: 178 srv_active, 0 srv_shutdown, 1244368 srv_idle
+srv_main_thread log flush and writes: 1244546
 ----------
 SEMAPHORES
 ----------
@@ -133,8 +133,8 @@ Per second averages calculated from the last 4 seconds
 -----------------
 BACKGROUND THREAD
 -----------------
-srv_master_thread loops: 1 srv_active, 0 srv_shutdown, 2 srv_idle
-srv_master_thread log flush and writes: 3
+srv_main_thread loops: 1 srv_active, 0 srv_shutdown, 2 srv_idle
+srv_main_thread log flush and writes: 3
 ----------
 SEMAPHORES
 ----------

--- a/parser/slave_status_test.go
+++ b/parser/slave_status_test.go
@@ -9,20 +9,20 @@ import (
 )
 
 const (
-	slaveStatus string = `
+	subordinateStatus string = `
 *************************** 1. row ***************************
-               Slave_IO_State: Waiting for master to send event
-                  Master_Host: db
-                  Master_User: mysql
-                  Master_Port: 3306
+               Subordinate_IO_State: Waiting for main to send event
+                  Main_Host: db
+                  Main_User: mysql
+                  Main_Port: 3306
                 Connect_Retry: 60
-              Master_Log_File: bin-log.000002
-          Read_Master_Log_Pos: 154
+              Main_Log_File: bin-log.000002
+          Read_Main_Log_Pos: 154
                Relay_Log_File: 29dc768b9532-relay-bin.000004
                 Relay_Log_Pos: 318
-        Relay_Master_Log_File: bin-log.000002
-             Slave_IO_Running: Yes
-            Slave_SQL_Running: Yes
+        Relay_Main_Log_File: bin-log.000002
+             Subordinate_IO_Running: Yes
+            Subordinate_SQL_Running: Yes
               Replicate_Do_DB:
           Replicate_Ignore_DB:
            Replicate_Do_Table:
@@ -32,74 +32,74 @@ const (
                    Last_Errno: 0
                    Last_Error:
                  Skip_Counter: 0
-          Exec_Master_Log_Pos: 154
+          Exec_Main_Log_Pos: 154
               Relay_Log_Space: 532
               Until_Condition: None
                Until_Log_File:
                 Until_Log_Pos: 0
-           Master_SSL_Allowed: No
-           Master_SSL_CA_File:
-           Master_SSL_CA_Path:
-              Master_SSL_Cert:
-            Master_SSL_Cipher:
-               Master_SSL_Key:
-        Seconds_Behind_Master: 0
-Master_SSL_Verify_Server_Cert: No
+           Main_SSL_Allowed: No
+           Main_SSL_CA_File:
+           Main_SSL_CA_Path:
+              Main_SSL_Cert:
+            Main_SSL_Cipher:
+               Main_SSL_Key:
+        Seconds_Behind_Main: 0
+Main_SSL_Verify_Server_Cert: No
                 Last_IO_Errno: 0
                 Last_IO_Error:
                Last_SQL_Errno: 0
                Last_SQL_Error:
   Replicate_Ignore_Server_Ids:
-             Master_Server_Id: 1
-                  Master_UUID: f8b8d2e3-7c1c-11ea-a3c4-0242ac120002
-             Master_Info_File: /var/lib/mysql/master.info
+             Main_Server_Id: 1
+                  Main_UUID: f8b8d2e3-7c1c-11ea-a3c4-0242ac120002
+             Main_Info_File: /var/lib/mysql/main.info
                     SQL_Delay: 0
           SQL_Remaining_Delay: NULL
-      Slave_SQL_Running_State: Slave has read all relay log; waiting for more updates
-           Master_Retry_Count: 86400
-                  Master_Bind:
+      Subordinate_SQL_Running_State: Subordinate has read all relay log; waiting for more updates
+           Main_Retry_Count: 86400
+                  Main_Bind:
       Last_IO_Error_Timestamp:
      Last_SQL_Error_Timestamp:
-               Master_SSL_Crl:
-           Master_SSL_Crlpath:
+               Main_SSL_Crl:
+           Main_SSL_Crlpath:
            Retrieved_Gtid_Set:
             Executed_Gtid_Set:
                 Auto_Position: 0
          Replicate_Rewrite_DB:
                  Channel_Name:
-           Master_TLS_Version:
+           Main_TLS_Version:
 `
 )
 
 var (
-	slaveStatusResult map[string]interface{} = map[string]interface{}{
+	subordinateStatusResult map[string]interface{} = map[string]interface{}{
 		"auto_position":                 0.0,
 		"connect_retry":                 60.0,
-		"exec_master_log_pos":           154.0,
+		"exec_main_log_pos":           154.0,
 		"last_errno":                    0.0,
 		"last_io_errno":                 0.0,
 		"last_sql_errno":                0.0,
-		"master_host":                   "db",
-		"master_info_file":              "/var/lib/mysql/master.info",
-		"master_log_file":               "bin-log.000002",
-		"master_port":                   3306.0,
-		"master_retry_count":            86400.0,
-		"master_server_id":              1.0,
-		"master_ssl_allowed":            "No",
-		"master_ssl_verify_server_cert": "No",
-		"master_user":                   "mysql",
-		"master_uuid":                   "f8b8d2e3-7c1c-11ea-a3c4-0242ac120002",
-		"read_master_log_pos":           154.0,
+		"main_host":                   "db",
+		"main_info_file":              "/var/lib/mysql/main.info",
+		"main_log_file":               "bin-log.000002",
+		"main_port":                   3306.0,
+		"main_retry_count":            86400.0,
+		"main_server_id":              1.0,
+		"main_ssl_allowed":            "No",
+		"main_ssl_verify_server_cert": "No",
+		"main_user":                   "mysql",
+		"main_uuid":                   "f8b8d2e3-7c1c-11ea-a3c4-0242ac120002",
+		"read_main_log_pos":           154.0,
 		"relay_log_file":                "29dc768b9532-relay-bin.000004",
 		"relay_log_pos":                 318.0,
 		"relay_log_space":               532.0,
-		"relay_master_log_file":         "bin-log.000002",
-		"seconds_behind_master":         0.0,
+		"relay_main_log_file":         "bin-log.000002",
+		"seconds_behind_main":         0.0,
 		"skip_counter":                  0.0,
-		"slave_io_running":              "Yes",
-		"slave_io_state":                "Waiting for master to send event",
-		"slave_sql_running":             "Yes",
-		"slave_sql_running_state":       "Slave has read all relay log; waiting for more updates",
+		"subordinate_io_running":              "Yes",
+		"subordinate_io_state":                "Waiting for main to send event",
+		"subordinate_sql_running":             "Yes",
+		"subordinate_sql_running_state":       "Subordinate has read all relay log; waiting for more updates",
 		"sql_delay":                     0.0,
 		"sql_remaining_delay":           "NULL",
 		"until_condition":               "None",
@@ -107,7 +107,7 @@ var (
 	}
 )
 
-func TestParseSlaveStatus(t *testing.T) {
+func TestParseSubordinateStatus(t *testing.T) {
 	cases := []struct {
 		name     string
 		str      string
@@ -115,15 +115,15 @@ func TestParseSlaveStatus(t *testing.T) {
 		err      error
 	}{
 		{
-			name:     "slave status",
-			str:      slaveStatus,
-			expected: slaveStatusResult,
+			name:     "subordinate status",
+			str:      subordinateStatus,
+			expected: subordinateStatusResult,
 			err:      nil,
 		},
 	}
 
 	for _, c := range cases {
-		actual, err := parser.ParseSlaveStatus(c.str)
+		actual, err := parser.ParseSubordinateStatus(c.str)
 		if err != nil {
 			t.Errorf("err: %s\n", err.Error())
 		}


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.